### PR TITLE
Bug fix for sveltekit/typescript users.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ module.exports = plugin(
         ([colorName, color]) =>
           (newUtilities[`.heropattern-${name}-${colorName}`] = {
             backgroundImage: pattern
-              .replace("{{color}}", color.replace("#", "%23"))
+              .replace("{{color}}", color.toString().replace("#", "%23"))
               .replace("{{opacity}}", 1), // TODO: maybe map all opacities here
           })
       )


### PR DESCRIPTION
Replaced method call to 'color.toString().replace("#", "%23")' on line 38 of index.js.
Resolved the error: [postcss] color.replace is not a function

(This will allow the plugin to play nice with Typescript/Sveltekit, and should not effect other technologies using this plugin.)